### PR TITLE
Simplify node configuration so you don't have to use an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,13 @@ promise.then((workspaces) => {
     - Run `yarn test`
 
 ### Integration tests
-Integration tests can be run locally by using `export INTEGRATION_TESTS=true export DEVELOPMENT=true`. Refer to the Environment variables section to learn more.
+Integration tests can be run locally by using `export INTEGRATION_TESTS=true`. Refer to the Environment variables section to learn more.
 
 **The devworkspace-controller must be on the cluster before running the integration tests.**
 
 ### Environment variables
 `INTEGRATION_TESTS`: When the INTEGRATION_TESTS environment variable is defined and it's value is true, the integration tests will run against your currently authenticated cluster.
 
-`DEVELOPMENT`: When the DEVELOPMENT environment variable is set, the authentication for `@kubernetes/client-node` is provided by your default local kubeconfig.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
  */
 
 import { AxiosInstance } from 'axios';
+import { INodeConfig } from './types';
 import { RestApi } from './browser';
 
 export * from './common/converter';
@@ -22,12 +23,14 @@ export class DevWorkspaceClient {
         return new RestApi(axios);
     }
 
-    public static getNodeApi() {
+    public static getNodeApi(config: INodeConfig = {
+        inCluster: true
+    }) {
         if (!DevWorkspaceClient.isItNode()) {
             throw new Error('getNodeApi is only available when running in nodejs');
         } else {
             const nodeApi = require('./node').NodeApi;
-            return new nodeApi();
+            return new nodeApi(config);
         }
     }
 

--- a/src/node/helper.ts
+++ b/src/node/helper.ts
@@ -10,8 +10,4 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-export const developmentId = 'DEVELOPMENT';
-export const isDevelopmentEnabled = () => developmentId in process.env && process.env[developmentId] === 'true';
-
-export const isInContainer = () => 'KUBERNETES_SERVICE_HOST' in process.env && 'KUBERNETES_SERVICE_PORT' in process.env;
-
+export const isInCluster = () => 'KUBERNETES_SERVICE_HOST' in process.env && 'KUBERNETES_SERVICE_PORT' in process.env;

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -10,18 +10,31 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+import * as k8s from '@kubernetes/client-node';
 import {
   IDevWorkspaceApi,
   IDevWorkspaceClientApi,
   INodeConfig,
 } from '../types';
+import { isInCluster } from './helper';
 import { NodeDevWorkspaceApi } from './workspace-api';
 
 export class NodeApi implements IDevWorkspaceClientApi {
   private _workspaceApi: IDevWorkspaceApi;
 
   constructor(config: INodeConfig) {
-    this._workspaceApi = new NodeDevWorkspaceApi(config);
+    const kc = new k8s.KubeConfig();
+    if (config.inCluster) {
+      if (!isInCluster()) {
+        throw new Error(
+          'Recieved error message when attempting to load authentication from cluster. Most likely you are not running inside of a container. Set environment variable DEVELOPMENT=true. See README.md for more details.'
+        );
+      }
+      kc.loadFromCluster();
+    } else {
+      kc.loadFromDefault();
+    }
+    this._workspaceApi = new NodeDevWorkspaceApi(kc);
   }
 
   get workspaceApi(): IDevWorkspaceApi {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -13,14 +13,15 @@
 import {
   IDevWorkspaceApi,
   IDevWorkspaceClientApi,
+  INodeConfig,
 } from '../types';
 import { NodeDevWorkspaceApi } from './workspace-api';
 
 export class NodeApi implements IDevWorkspaceClientApi {
   private _workspaceApi: IDevWorkspaceApi;
 
-  constructor() {
-    this._workspaceApi = new NodeDevWorkspaceApi();
+  constructor(config: INodeConfig) {
+    this._workspaceApi = new NodeDevWorkspaceApi(config);
   }
 
   get workspaceApi(): IDevWorkspaceApi {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -27,7 +27,7 @@ export class NodeApi implements IDevWorkspaceClientApi {
     if (config.inCluster) {
       if (!isInCluster()) {
         throw new Error(
-          'Recieved error message when attempting to load authentication from cluster. Most likely you are not running inside of a container. Set environment variable DEVELOPMENT=true. See README.md for more details.'
+          'Recieved error message when attempting to load authentication from cluster. Most likely you are not running inside of a container.'
         );
       }
       kc.loadFromCluster();

--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -15,7 +15,6 @@ import {
   IDevWorkspace,
   IDevWorkspaceDevfile,
   IKubernetesGroupsModel,
-  INodeConfig,
 } from '../types';
 import { devfileToDevWorkspace, IDevWorkspaceApi } from '../index';
 import {
@@ -26,24 +25,12 @@ import {
 } from '../common';
 import { projectRequestModel } from '../common/models';
 import { handleGenericError } from './errors';
-import { isInCluster } from './helper';
 
 export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
   private customObjectAPI: k8s.CustomObjectsApi;
   private apisApi: k8s.ApisApi;
 
-  constructor(config: INodeConfig) {
-    const kc = new k8s.KubeConfig();
-    if (config.inCluster) {
-      if (!isInCluster()) {
-        throw new Error(
-          'Recieved error message when attempting to load authentication from cluster. Most likely you are not running inside of a container. Set environment variable DEVELOPMENT=true. See README.md for more details.'
-        );
-      }
-      kc.loadFromCluster();
-    } else {
-      kc.loadFromDefault();
-    }
+  constructor(kc: k8s.KubeConfig) {
     this.customObjectAPI = kc.makeApiClient(k8s.CustomObjectsApi);
     this.apisApi = kc.makeApiClient(k8s.ApisApi);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,10 @@ export interface IDevWorkspaceDevfile {
     events?: any;
 }
 
+export interface INodeConfig {
+    inCluster: boolean;
+}
+
 export interface IKubernetesGroupsModel {
     name: string;
 }


### PR DESCRIPTION
This PR simplifies configuration when using the node api. You are now able to specify a config rather than an env variable for specifiying in cluster/out of cluster development

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>