### PR TITLE
Add in devworkspacetemplates implementations

### DIFF
--- a/src/browser/helper.ts
+++ b/src/browser/helper.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { AxiosInstance } from 'axios';
+import { IKubernetesGroupsModel } from '../types';
+import { projectApiGroup } from '../common';
+
+export async function isOpenShiftCluster(axios: AxiosInstance): Promise<boolean> {
+    return findApi(axios, projectApiGroup);
+}
+
+export async function findApi(axios: AxiosInstance, apiName: string, version?: string): Promise<boolean> {
+    const resp = await axios.get('/apis');
+    const responseData = await resp.data.groups;
+    return responseData.filter((apiGroup: IKubernetesGroupsModel) => {
+        if (version) {
+            return apiGroup.name === apiName && apiGroup.versions.filter(versionGroup => versionGroup.version === version).length > 0;
+        }
+        return apiGroup.name === apiName;
+    }).length > 0;
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -11,20 +11,41 @@
  */
 
 import { AxiosInstance } from 'axios';
+import { devWorkspaceApiGroup, devworkspaceVersion } from '../common';
 import {
   IDevWorkspaceApi,
   IDevWorkspaceClientApi,
+  IDevWorkspaceTemplateApi,
 } from '../types';
+import { findApi } from './helper';
 import { RestDevWorkspaceApi } from './workspace-api';
+import { RestDevWorkspaceTemplateApi } from './template-api';
 
 export class RestApi implements IDevWorkspaceClientApi {
+  private axios: AxiosInstance;
   private _workspaceApi: IDevWorkspaceApi;
+  private _templateApi: IDevWorkspaceTemplateApi;
+  private apiEnabled: boolean | undefined;
 
   constructor(axios: AxiosInstance) {
+    this.axios = axios;
     this._workspaceApi = new RestDevWorkspaceApi(axios);
+    this._templateApi = new RestDevWorkspaceTemplateApi(axios);
   }
 
   get workspaceApi(): IDevWorkspaceApi {
     return this._workspaceApi;
+  }
+
+  get templateApi(): IDevWorkspaceTemplateApi {
+    return this._templateApi;
+  }
+
+  async isDevWorkspaceApiEnabled(): Promise<boolean> {
+    if (this.apiEnabled !== undefined) {
+      return Promise.resolve(this.apiEnabled);
+    }
+    this.apiEnabled = await findApi(this.axios, devWorkspaceApiGroup, devworkspaceVersion);
+    return this.apiEnabled;
   }
 }

--- a/src/browser/template-api.ts
+++ b/src/browser/template-api.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { AxiosInstance } from 'axios';
+import { IDevWorkspaceTemplate, IDevWorkspaceTemplateApi } from '../types';
+import { devworkspaceVersion, devWorkspaceApiGroup, devworkspaceTemplateSubresource } from '../common';
+
+export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
+  private axios: AxiosInstance;
+
+  constructor(axios: AxiosInstance) {
+    this.axios = axios;
+  }
+
+  async listInNamespace(namespace: string): Promise<IDevWorkspaceTemplate[]> {
+    const resp = await this.axios.get(
+      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}`
+    );
+    return resp.data.items;
+  }
+
+  async getByName(
+    namespace: string,
+    workspaceName: string
+  ): Promise<IDevWorkspaceTemplate> {
+    const resp = await this.axios.get(
+      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}/${workspaceName}`
+    );
+    return resp.data;
+  }
+
+  async create(
+    devworkspaceTemplate: IDevWorkspaceTemplate,
+  ): Promise<IDevWorkspaceTemplate> {
+    const resp = await this.axios.post(
+      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspaceTemplate.metadata.namespace}/${devworkspaceTemplateSubresource}`,
+      devworkspaceTemplate,
+      {
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+        },
+      }
+    );
+    return resp.data;
+  }
+
+  async delete(namespace: string, name: string): Promise<void> {
+    this.axios.delete(
+      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}/${name}`
+    );
+  }
+}

--- a/src/common/converter.ts
+++ b/src/common/converter.ts
@@ -11,12 +11,12 @@
  */
 
 import { IDevWorkspace, IDevWorkspaceDevfile } from '../types';
-import { devworkspaceVersion, group } from '.';
+import { devworkspaceVersion, devWorkspaceApiGroup } from '.';
 
 export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile): IDevWorkspace {
     devfile.metadata.annotations = {};
     const template = {
-        apiVersion: `${group}/${devworkspaceVersion}`,
+        apiVersion: `${devWorkspaceApiGroup}/${devworkspaceVersion}`,
         kind: 'DevWorkspace',
         metadata: devfile.metadata,
         spec: {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -11,8 +11,10 @@
  */
 
 export const devworkspaceVersion = 'v1alpha2';
-export const group = 'workspace.devfile.io';
 export const devworkspaceSubresource = 'devworkspaces';
+export const devworkspaceTemplateSubresource = 'devworkspacetemplates';
+export const projectsId = 'projects';
+export const projectRequestId = 'projectrequests';
 
-export const openshiftIdentifier = 'project.openshift.io';
-export const devworkspaceIdentifier = 'workspace.devfile.io';
+export const projectApiGroup = 'project.openshift.io';
+export const devWorkspaceApiGroup = 'workspace.devfile.io';

--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -10,11 +10,11 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { openshiftIdentifier } from '.';
+import { projectApiGroup } from '.';
 
 export const projectRequestModel = (namespace: string) => {
   return {
-    apiVersion: `${openshiftIdentifier}/v1`,
+    apiVersion: `${projectApiGroup}/v1`,
     kind: 'ProjectRequest',
     metadata: {
       name: namespace,

--- a/src/node/template-api.ts
+++ b/src/node/template-api.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import { devWorkspaceApiGroup, devworkspaceTemplateSubresource, devworkspaceVersion } from '../common';
+import {
+    IDevWorkspaceTemplate,
+    IDevWorkspaceTemplateApi,
+} from '../types';
+import { handleGenericError } from './errors';
+
+export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
+    private customObjectAPI: k8s.CustomObjectsApi;
+
+    constructor(kc: k8s.KubeConfig) {
+        this.customObjectAPI = kc.makeApiClient(k8s.CustomObjectsApi);
+    }
+
+    async listInNamespace(namespace: string): Promise<IDevWorkspaceTemplate[]> {
+        try {
+            const resp = await this.customObjectAPI.listNamespacedCustomObject(
+                devWorkspaceApiGroup,
+                devworkspaceVersion,
+                namespace,
+                devworkspaceTemplateSubresource
+            );
+            return (resp.body as any).items as IDevWorkspaceTemplate[];
+        } catch (e) {
+            throw handleGenericError(e);
+        }
+    }
+
+    async getByName(namespace: string, workspaceName: string): Promise<IDevWorkspaceTemplate> {
+        try {
+            const resp = await this.customObjectAPI.getNamespacedCustomObject(
+                devWorkspaceApiGroup,
+                devworkspaceVersion,
+                namespace,
+                devworkspaceTemplateSubresource,
+                workspaceName
+            );
+            return resp.body as IDevWorkspaceTemplate;
+        } catch (e) {
+            throw handleGenericError(e);
+        }
+    }
+
+    async create(
+        devworkspaceTemplate: IDevWorkspaceTemplate,
+    ): Promise<IDevWorkspaceTemplate> {
+        try {
+            const namespace = devworkspaceTemplate.metadata.namespace;
+            const resp = await this.customObjectAPI.createNamespacedCustomObject(
+                devWorkspaceApiGroup,
+                devworkspaceVersion,
+                namespace,
+                devworkspaceTemplateSubresource,
+                devworkspaceTemplate
+            );
+            return resp.body as IDevWorkspaceTemplate;
+        } catch (e) {
+            throw handleGenericError(e);
+        }
+    }
+
+    async delete(namespace: string, name: string): Promise<void> {
+        try {
+            this.customObjectAPI.deleteNamespacedCustomObject(
+                devWorkspaceApiGroup,
+                devworkspaceVersion,
+                namespace,
+                devworkspaceTemplateSubresource,
+                name
+            );
+        } catch (e) {
+            throw handleGenericError(e);
+        }
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,21 +11,29 @@
  */
 
 export interface IDevWorkspaceApi {
-    getAllWorkspaces(namespace: string): Promise<IDevWorkspace[]>;
-    getWorkspaceByName(namespace: string, workspaceName: string): Promise<IDevWorkspace>;
+    listInNamespace(namespace: string): Promise<IDevWorkspace[]>;
+    getByName(namespace: string, workspaceName: string): Promise<IDevWorkspace>;
     create(
         devfile: IDevWorkspaceDevfile,
         defaultEditor?: string,
         defaultPlugins?: string[]
     ): Promise<IDevWorkspace>;
     delete(namespace: string, name: string): Promise<void>;
-    changeWorkspaceStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace>;
+    changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace>;
     initializeNamespace(namespace: string): Promise<void>;
-    isApiEnabled(): Promise<boolean>;
+}
+
+export interface IDevWorkspaceTemplateApi {
+    listInNamespace(namespace: string): Promise<IDevWorkspaceTemplate[]>;
+    getByName(namespace: string, workspaceName: string): Promise<IDevWorkspaceTemplate>;
+    delete(namespace: string, name: string): Promise<void>;
+    create(template: IDevWorkspaceTemplate): Promise<IDevWorkspaceTemplate>;
 }
 
 export interface IDevWorkspaceClientApi {
     workspaceApi: IDevWorkspaceApi;
+    templateApi: IDevWorkspaceTemplateApi;
+    isDevWorkspaceApiEnabled(): Promise<boolean>;
 }
 
 export interface IDevWorkspace {
@@ -53,6 +61,16 @@ export interface IDevWorkspace {
     };
 }
 
+export interface IDevWorkspaceTemplate {
+    apiVersion: string;
+    kind: string;
+    metadata: {
+        name: string;
+        namespace: string;
+    };
+    spec: IDevWorkspaceDevfile;
+}
+
 export interface IDevWorkspaceDevfile {
     schemaVersion: string;
     metadata: {
@@ -72,4 +90,7 @@ export interface INodeConfig {
 
 export interface IKubernetesGroupsModel {
     name: string;
+    versions: {
+        version: string;
+    }[];
 }

--- a/test/fixtures/sample-dwt.yaml
+++ b/test/fixtures/sample-dwt.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  name: sample-dwt
+  namespace: sample
+spec:
+  projects: []
+  components: []
+  commands: []
+  events: {}


### PR DESCRIPTION
This PR implements the handling of devworkspacetemplates on both the browser and node side. It's based on https://github.com/che-incubator/devworkspace-client/pull/3 so once that's merged I can rebase