### PR TITLE
Make sure components is defined before pushing

### DIFF
--- a/src/browser/workspace-api.ts
+++ b/src/browser/workspace-api.ts
@@ -56,6 +56,9 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
     const devworkspace = devfileToDevWorkspace(devfile);
 
     if (defaultEditor && !hasEditor(devfile)) {
+      if (!devworkspace.spec.template.components) {
+        devworkspace.spec.template.components = [];
+      }
       devworkspace.spec.template.components.push(
         createKubernetesComponent(defaultEditor)
       );
@@ -65,6 +68,9 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
       ? pluginsToInject(devfile, defaultPlugins)
       : [];
     if (pluginsNeeded.length > 0) {
+      if (!devworkspace.spec.template.components) {
+        devworkspace.spec.template.components = [];
+      }
       for (const plugin of pluginsNeeded) {
         devworkspace.spec.template.components.push(
           createKubernetesComponent(plugin)


### PR DESCRIPTION
Fix for: `Failed to create a new workspace from the devfile: Cannot read property 'push' of undefined` in https://github.com/eclipse/che-dashboard/pull/175#pullrequestreview-597468291

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>