### PR TITLE
Add che routing class

### DIFF
--- a/src/common/converter.ts
+++ b/src/common/converter.ts
@@ -21,6 +21,7 @@ export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile): IDevWorksp
         metadata: devfile.metadata,
         spec: {
             started: true,
+            routingClass: 'che',
             template: {
                 components: []
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface IDevWorkspace {
     };
     spec: {
         started: boolean;
+        routingClass: string;
         template: {
             projects?: any;
             components?: any;


### PR DESCRIPTION
This PR adds in the Che routing class by default. We can either do it this way or alternatively we can pass in the routing class via the create method. I'm fine with either, but one thing to note is that this code would be removed from the devworkspace-client and added to the devworkspace-che-client when/if we submit this to the cncf

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>