### PR TITLE
Add new che specific rest api

### DIFF
--- a/src/browser/che-api.ts
+++ b/src/browser/che-api.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { AxiosInstance } from 'axios';
+import { delay } from '../common/helper';
+import { projectApiGroup, projectRequestId, projectsId } from '../common';
+import { projectRequestModel } from '../common/models';
+import { isOpenShiftCluster } from './helper';
+import { ICheApi } from '../types';
+
+export class RestCheApi implements ICheApi {
+  private axios: AxiosInstance;
+  private projectInitRequestTimeoutMs = 10000;
+  private projectRequestDelayMs = 100;
+
+  constructor(axios: AxiosInstance) {
+    this.axios = axios;
+  }
+
+  async initializeNamespace(namespace: string): Promise<void> {
+    const isOpenShift = await isOpenShiftCluster(this.axios);
+    if (isOpenShift) {
+      const doesProjectAlreadyExist = await this.doesProjectExist(namespace);
+      if (!doesProjectAlreadyExist) {
+        this.createProject(namespace);
+        await this.waitForProjectToBeReady(namespace);
+      }
+    }
+  }
+
+  private async doesProjectExist(projectName: string): Promise<boolean> {
+    try {
+      const projects = await this.axios.get(`/apis/${projectApiGroup}/v1/${projectsId}`);
+      for (const proj of projects.data.items) {
+        if (proj.metadata.name === projectName) {
+          return true;
+        }
+      }
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  private createProject(namespace: string): void {
+    this.axios.post(`/apis/${projectApiGroup}/v1/${projectRequestId}`, projectRequestModel(namespace));
+  }
+
+  private async waitForProjectToBeReady(namespace: string): Promise<void> {
+    let millisecondsAttempted = 0;
+    let request = await this.doesProjectExist(namespace);
+    while (millisecondsAttempted < this.projectInitRequestTimeoutMs && !request) {
+      request = await this.doesProjectExist(namespace);
+      await delay(this.projectRequestDelayMs);
+      millisecondsAttempted += this.projectRequestDelayMs;
+    }
+    if (millisecondsAttempted >= this.projectInitRequestTimeoutMs) {
+      throw new Error(`Project ${namespace} could not be initialized in ${this.projectInitRequestTimeoutMs / 1000} seconds`);
+    }
+  }
+
+}

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -13,6 +13,7 @@
 import { AxiosInstance } from 'axios';
 import { devWorkspaceApiGroup, devworkspaceVersion } from '../common';
 import {
+  ICheApi,
   IDevWorkspaceApi,
   IDevWorkspaceClientApi,
   IDevWorkspaceTemplateApi,
@@ -20,17 +21,20 @@ import {
 import { findApi } from './helper';
 import { RestDevWorkspaceApi } from './workspace-api';
 import { RestDevWorkspaceTemplateApi } from './template-api';
+import { RestCheApi } from './che-api';
 
 export class RestApi implements IDevWorkspaceClientApi {
   private axios: AxiosInstance;
   private _workspaceApi: IDevWorkspaceApi;
   private _templateApi: IDevWorkspaceTemplateApi;
+  private _cheApi: ICheApi;
   private apiEnabled: boolean | undefined;
 
   constructor(axios: AxiosInstance) {
     this.axios = axios;
     this._workspaceApi = new RestDevWorkspaceApi(axios);
     this._templateApi = new RestDevWorkspaceTemplateApi(axios);
+    this._cheApi = new RestCheApi(axios);
   }
 
   get workspaceApi(): IDevWorkspaceApi {
@@ -39,6 +43,10 @@ export class RestApi implements IDevWorkspaceClientApi {
 
   get templateApi(): IDevWorkspaceTemplateApi {
     return this._templateApi;
+  }
+
+  get cheApi(): ICheApi {
+    return this._cheApi;
   }
 
   async isDevWorkspaceApiEnabled(): Promise<boolean> {

--- a/src/browser/workspace-api.ts
+++ b/src/browser/workspace-api.ts
@@ -44,9 +44,10 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
 
   async create(
     devfile: IDevWorkspaceDevfile,
+    routingClass: string,
     started = true
   ): Promise<IDevWorkspace> {
-    const devworkspace = devfileToDevWorkspace(devfile, started);
+    const devworkspace = devfileToDevWorkspace(devfile, routingClass, started);
     const stringifiedDevWorkspace = JSON.stringify(devworkspace);
 
     const resp = await this.axios.post(

--- a/src/common/converter.ts
+++ b/src/common/converter.ts
@@ -13,7 +13,7 @@
 import { IDevWorkspace, IDevWorkspaceDevfile } from '../types';
 import { devworkspaceVersion, devWorkspaceApiGroup } from '.';
 
-export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile, started: boolean): IDevWorkspace {
+export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile, routingClass: string, started: boolean): IDevWorkspace {
     devfile.metadata.annotations = {};
     const template = {
         apiVersion: `${devWorkspaceApiGroup}/${devworkspaceVersion}`,
@@ -21,7 +21,7 @@ export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile, started: bo
         metadata: devfile.metadata,
         spec: {
             started,
-            routingClass: 'che',
+            routingClass,
             template: {
                 components: []
             }

--- a/src/node/che-api.ts
+++ b/src/node/che-api.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import {
+    ICheApi,
+} from '../types';
+import {
+  projectApiGroup,
+  projectRequestId,
+  projectsId,
+} from '../common';
+import { projectRequestModel } from '../common/models';
+import { handleGenericError } from './errors';
+import { findApi } from './helper';
+
+export class NodeCheApi implements ICheApi {
+  private customObjectAPI: k8s.CustomObjectsApi;
+  private apisApi: k8s.ApisApi;
+
+  constructor(kc: k8s.KubeConfig) {
+    this.customObjectAPI = kc.makeApiClient(k8s.CustomObjectsApi);
+    this.apisApi = kc.makeApiClient(k8s.ApisApi);
+  }
+
+  async initializeNamespace(namespace: string): Promise<void> {
+    try {
+      const isOpenShift = await this.isOpenShift();
+      if (isOpenShift) {
+        const doesProjectAlreadyExist = await this.doesProjectExist(namespace);
+        if (!doesProjectAlreadyExist) {
+          this.createProject(namespace);
+        }
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  async doesProjectExist(projectName: string): Promise<boolean> {
+    try {
+      const resp = await this.customObjectAPI.listClusterCustomObject(projectApiGroup, 'v1', projectsId);
+      const projectList = (resp.body as any).items;
+      return (
+        projectList.filter((x: any) => x.metadata.name === projectName)
+          .length > 0
+      );
+    } catch (e) {
+      return false;
+    }
+  }
+
+  private async createProject(namespace: string): Promise<void> {
+    try {
+      await this.customObjectAPI.createClusterCustomObject(
+        projectApiGroup,
+        'v1',
+        projectRequestId,
+        projectRequestModel(namespace)
+      );
+    } catch (e) {
+      throw handleGenericError(e);
+    }
+  }
+
+  private async isOpenShift(): Promise<boolean> {
+    try {
+      return findApi(this.apisApi, projectApiGroup);
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -13,11 +13,13 @@
 import * as k8s from '@kubernetes/client-node';
 import { devWorkspaceApiGroup, devworkspaceVersion } from '../common';
 import {
+  ICheApi,
   IDevWorkspaceApi,
   IDevWorkspaceClientApi,
   IDevWorkspaceTemplateApi,
   INodeConfig,
 } from '../types';
+import { NodeCheApi } from './che-api';
 import { findApi, isInCluster } from './helper';
 import { NodeDevWorkspaceTemplateApi } from './template-api';
 import { NodeDevWorkspaceApi } from './workspace-api';
@@ -25,6 +27,7 @@ import { NodeDevWorkspaceApi } from './workspace-api';
 export class NodeApi implements IDevWorkspaceClientApi {
   private _workspaceApi: IDevWorkspaceApi;
   private _templateApi: IDevWorkspaceTemplateApi;
+  private _cheApi: ICheApi;
   private apisApi: k8s.ApisApi;
   private apiEnabled: boolean | undefined;
 
@@ -42,6 +45,7 @@ export class NodeApi implements IDevWorkspaceClientApi {
     }
     this._workspaceApi = new NodeDevWorkspaceApi(kc);
     this._templateApi = new NodeDevWorkspaceTemplateApi(kc);
+    this._cheApi = new NodeCheApi(kc);
     this.apisApi = kc.makeApiClient(k8s.ApisApi);
   }
 
@@ -51,6 +55,10 @@ export class NodeApi implements IDevWorkspaceClientApi {
 
   get templateApi(): IDevWorkspaceTemplateApi {
     return this._templateApi;
+  }
+
+  get cheApi(): ICheApi {
+    return this._cheApi;
   }
 
   async isDevWorkspaceApiEnabled(): Promise<boolean> {

--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -20,13 +20,8 @@ import {
   devworkspacePluralSubresource,
   devworkspaceVersion,
   devWorkspaceApiGroup,
-  projectApiGroup,
-  projectRequestId,
-  projectsId,
 } from '../common';
-import { projectRequestModel } from '../common/models';
 import { handleGenericError } from './errors';
-import { findApi } from './helper';
 
 export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
   private customObjectAPI: k8s.CustomObjectsApi;
@@ -167,54 +162,6 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       return resp.body as IDevWorkspace;
     } catch (e) {
       throw handleGenericError(e);
-    }
-  }
-
-  async initializeNamespace(namespace: string): Promise<void> {
-    try {
-      const isOpenShift = await this.isOpenShift();
-      if (isOpenShift) {
-        const doesProjectAlreadyExist = await this.doesProjectExist(namespace);
-        if (!doesProjectAlreadyExist) {
-          this.createProject(namespace);
-        }
-      }
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  async doesProjectExist(projectName: string): Promise<boolean> {
-    try {
-      const resp = await this.customObjectAPI.listClusterCustomObject(projectApiGroup, 'v1', projectsId);
-      const projectList = (resp.body as any).items;
-      return (
-        projectList.filter((x: any) => x.metadata.name === projectName)
-          .length > 0
-      );
-    } catch (e) {
-      return false;
-    }
-  }
-
-  private async createProject(namespace: string): Promise<void> {
-    try {
-      await this.customObjectAPI.createClusterCustomObject(
-        projectApiGroup,
-        'v1',
-        projectRequestId,
-        projectRequestModel(namespace)
-      );
-    } catch (e) {
-      throw handleGenericError(e);
-    }
-  }
-
-  private async isOpenShift(): Promise<boolean> {
-    try {
-      return findApi(this.apisApi, projectApiGroup);
-    } catch (e) {
-      return false;
     }
   }
 }

--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -66,10 +66,11 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
 
   async create(
     devfile: IDevWorkspaceDevfile,
+    routingClass: string,
     started: boolean = true
   ): Promise<IDevWorkspace> {
     try {
-      const devworkspace = devfileToDevWorkspace(devfile, started);
+      const devworkspace = devfileToDevWorkspace(devfile, routingClass, started);
       const namespace = devfile.metadata.namespace;
       const resp = await this.customObjectAPI.createNamespacedCustomObject(
         devWorkspaceApiGroup,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,6 @@ export interface IDevWorkspaceApi {
     update(devworkspace: IDevWorkspace): Promise<IDevWorkspace>;
     delete(namespace: string, name: string): Promise<void>;
     changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace>;
-    initializeNamespace(namespace: string): Promise<void>;
 }
 
 export interface IDevWorkspaceTemplateApi {
@@ -34,6 +33,10 @@ export interface IDevWorkspaceClientApi {
     workspaceApi: IDevWorkspaceApi;
     templateApi: IDevWorkspaceTemplateApi;
     isDevWorkspaceApiEnabled(): Promise<boolean>;
+}
+
+export interface ICheApi {
+    initializeNamespace(namespace: string): Promise<void>;
 }
 
 export interface IDevWorkspace {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,8 @@ export interface IDevWorkspaceApi {
     getByName(namespace: string, workspaceName: string): Promise<IDevWorkspace>;
     create(
         devfile: IDevWorkspaceDevfile,
-        started?: boolean
+        routingClass: string,
+        started?: boolean,
     ): Promise<IDevWorkspace>;
     update(devworkspace: IDevWorkspace): Promise<IDevWorkspace>;
     delete(namespace: string, name: string): Promise<void>;

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -20,7 +20,7 @@ describe('testing sample conversions', () => {
         test('the sample-devfile fixture should convert into sample-devworkspace fixture', () => {
             const input: any = yaml.load(fs.readFileSync(__dirname + '/fixtures/sample-devfile.yaml', 'utf-8'));
             const output = yaml.load(fs.readFileSync(__dirname + '/fixtures/sample-devworkspace.yaml', 'utf-8'));
-            expect(devfileToDevWorkspace(input, true)).toStrictEqual(output);
+            expect(devfileToDevWorkspace(input, 'che', true)).toStrictEqual(output);
         });
     });
 

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -34,7 +34,7 @@ describe('DevWorkspace API integration testing against cluster', () => {
             expect(isApiEnabled).toBe(true);
 
             // check that the namespace is initialized
-            await nodeApi.workspaceApi.initializeNamespace(namespace);
+            await nodeApi.cheApi.initializeNamespace(namespace);
             await delay(5000);
             const projectExists = await (nodeApi.workspaceApi as any).doesProjectExist(namespace);
             expect(projectExists).toBe(true);
@@ -89,7 +89,7 @@ describe('DevWorkspace API integration testing against cluster', () => {
             expect(isApiEnabled).toBe(true);
 
             // initialize project if it doesn't exist
-            await nodeApi.workspaceApi.initializeNamespace(namespace);
+            await nodeApi.cheApi.initializeNamespace(namespace);
             await delay(5000);
             const projectExists = await (nodeApi.workspaceApi as any).doesProjectExist(namespace);
             expect(projectExists).toBe(true);

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -36,11 +36,11 @@ describe('DevWorkspace API integration testing against cluster', () => {
             // check that the namespace is initialized
             await nodeApi.cheApi.initializeNamespace(namespace);
             await delay(5000);
-            const projectExists = await (nodeApi.workspaceApi as any).doesProjectExist(namespace);
+            const projectExists = await (nodeApi.cheApi as any).doesProjectExist(namespace);
             expect(projectExists).toBe(true);
 
             // check that creation works
-            const newDevWorkspace = await nodeApi.workspaceApi.create(devfile);
+            const newDevWorkspace = await nodeApi.workspaceApi.create(devfile, 'che', true);
             expect(newDevWorkspace.metadata.name).toBe(name);
             expect(newDevWorkspace.metadata.namespace).toBe(namespace);
 
@@ -91,7 +91,7 @@ describe('DevWorkspace API integration testing against cluster', () => {
             // initialize project if it doesn't exist
             await nodeApi.cheApi.initializeNamespace(namespace);
             await delay(5000);
-            const projectExists = await (nodeApi.workspaceApi as any).doesProjectExist(namespace);
+            const projectExists = await (nodeApi.cheApi as any).doesProjectExist(namespace);
             expect(projectExists).toBe(true);
 
             // check that creation works


### PR DESCRIPTION
This PR moves all the che specific browser side parts to a new Che api specific class

You can test the browser side with: https://github.com/eclipse/che-dashboard/tree/che-rest-api and just make sure that the namespace is created as expected (though I've just moved files around so nothing really changed)

To test the node changes:
```
export INTEGRATION_TESTS=true
yarn test
```
and the tests will run in your cluster in the sample namespace. You must make sure that the devworkspace-operator is installed before-hand otherwise the tests will fail.

Related issue: https://github.com/eclipse/che/issues/19382

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>