### PR TITLE
Handle browser errors the same way as che workspace client

### DIFF
--- a/src/browser/helper.ts
+++ b/src/browser/helper.ts
@@ -49,7 +49,7 @@ export interface IRequestError extends Error {
     response?: IResponse<any>;
 }
 
-export class RequestError implements IRequestError {
+export class BrowserRequestError implements IRequestError {
 
     status: number | undefined;
     name: string;

--- a/src/browser/helper.ts
+++ b/src/browser/helper.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { AxiosInstance } from 'axios';
+import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { IKubernetesGroupsModel } from '../types';
 import { projectApiGroup } from '../common';
 
@@ -27,4 +27,68 @@ export async function findApi(axios: AxiosInstance, apiName: string, version?: s
         }
         return apiGroup.name === apiName;
     }).length > 0;
+}
+
+
+export interface IRequestConfig extends AxiosRequestConfig {
+}
+
+export interface IResponse<T> extends AxiosResponse<T> {
+    data: T;
+    status: number;
+    statusText: string;
+    headers: any;
+    config: IRequestConfig;
+    request?: any;
+}
+
+export interface IRequestError extends Error {
+    status?: number;
+    config: AxiosRequestConfig;
+    request?: any;
+    response?: IResponse<any>;
+}
+
+export class RequestError implements IRequestError {
+
+    status: number | undefined;
+    name: string;
+    message: string;
+    config: AxiosRequestConfig;
+    request: any;
+    response: AxiosResponse | undefined;
+
+    constructor(error: AxiosError) {
+        if (error.code) {
+            this.status = Number(error.code);
+        }
+        this.name = error.name;
+        this.config = error.config;
+        if (error.request) {
+            this.request = error.request;
+        }
+        if (error.response) {
+            this.response = error.response;
+        }
+        if ((this.status === -1 || !this.status) && (!this.response  || (this.response && !this.response.status))) {
+            // request is interrupted, there is not even an error
+            this.message = `network issues occured while requesting "${this.config.url}".`;
+        } else if (this.response && this.response.data && this.response.data.message) {
+            // che Server error that should be self-descriptive
+            this.message = this.response.data.message;
+        } else {
+            // the error is not from Che Server, so error may be in html format that we're not able to handle.
+            // displaying just a error code and URL.
+
+            // sometimes status won't be defined, so when it's not look into the response status more info
+            let status = this.status;
+            if (!this.status && this.response && this.response.status) {
+                status = this.response.status;
+            // defer to the status code of the request if there is no response
+            } else if (!this.status && this.request && this.request.status) {
+                status = this.request.status;
+            }
+            this.message = `"${status}" returned by "${this.config.url}"."`;
+        }
+    }
 }

--- a/src/browser/template-api.ts
+++ b/src/browser/template-api.ts
@@ -13,7 +13,7 @@
 import { AxiosInstance } from 'axios';
 import { IDevWorkspaceTemplate, IDevWorkspaceTemplateApi } from '../types';
 import { devworkspaceVersion, devWorkspaceApiGroup, devworkspaceTemplateSubresource } from '../common';
-import { RequestError } from './helper';
+import { BrowserRequestError } from './helper';
 
 export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
   private _axios: AxiosInstance;
@@ -33,7 +33,7 @@ export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
       );
       return resp.data.items;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 
@@ -47,7 +47,7 @@ export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
       );
       return resp.data;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 
@@ -66,7 +66,7 @@ export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
       );
       return resp.data;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 

--- a/src/browser/template-api.ts
+++ b/src/browser/template-api.ts
@@ -13,6 +13,7 @@
 import { AxiosInstance } from 'axios';
 import { IDevWorkspaceTemplate, IDevWorkspaceTemplateApi } from '../types';
 import { devworkspaceVersion, devWorkspaceApiGroup, devworkspaceTemplateSubresource } from '../common';
+import { RequestError } from './helper';
 
 export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
   private _axios: AxiosInstance;
@@ -26,35 +27,47 @@ export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
   };
 
   async listInNamespace(namespace: string): Promise<IDevWorkspaceTemplate[]> {
-    const resp = await this._axios.get(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}`
-    );
-    return resp.data.items;
+    try {
+      const resp = await this._axios.get(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}`
+      );
+      return resp.data.items;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
+    }
   }
 
   async getByName(
     namespace: string,
     workspaceName: string
   ): Promise<IDevWorkspaceTemplate> {
-    const resp = await this._axios.get(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}/${workspaceName}`
-    );
-    return resp.data;
+    try {
+      const resp = await this._axios.get(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}/${workspaceName}`
+      );
+      return resp.data;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
+    }
   }
 
   async create(
     devworkspaceTemplate: IDevWorkspaceTemplate,
   ): Promise<IDevWorkspaceTemplate> {
-    const resp = await this._axios.post(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspaceTemplate.metadata.namespace}/${devworkspaceTemplateSubresource}`,
-      devworkspaceTemplate,
-      {
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-        },
-      }
-    );
-    return resp.data;
+    try {
+      const resp = await this._axios.post(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspaceTemplate.metadata.namespace}/${devworkspaceTemplateSubresource}`,
+        devworkspaceTemplate,
+        {
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+          },
+        }
+      );
+      return resp.data;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
+    }
   }
 
   async delete(namespace: string, name: string): Promise<void> {

--- a/src/browser/workspace-api.ts
+++ b/src/browser/workspace-api.ts
@@ -15,9 +15,9 @@ import { devfileToDevWorkspace } from '../common/converter';
 import { IDevWorkspace, IDevWorkspaceDevfile } from '../types';
 import { deletePolicy, deletionOptions } from '../common/models';
 import { IDevWorkspaceApi } from '../index';
-import { devworkspaceVersion, devWorkspaceApiGroup, devworkspacePluralSubresource } from '../common';
-import { RequestError } from './helper';
 import { delay } from '../common/helper';
+import { devworkspaceVersion, devWorkspaceApiGroup, devworkspacePluralSubresource } from '../common';
+import { BrowserRequestError } from './helper';
 
 export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   private _axios: AxiosInstance;
@@ -37,7 +37,7 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.data.items;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 
@@ -51,7 +51,7 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.data;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 
@@ -97,7 +97,7 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
       }
       return found;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 
@@ -116,7 +116,7 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.data;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 
@@ -152,7 +152,7 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.data;
     } catch (e) {
-      return Promise.reject(new RequestError(e));
+      return Promise.reject(new BrowserRequestError(e));
     }
   }
 }

--- a/src/browser/workspace-api.ts
+++ b/src/browser/workspace-api.ts
@@ -13,10 +13,11 @@
 import { AxiosInstance } from 'axios';
 import { devfileToDevWorkspace } from '../common/converter';
 import { IDevWorkspace, IDevWorkspaceDevfile } from '../types';
-import { delay } from '../common/helper';
-import { IDevWorkspaceApi } from '../types';
-import { devworkspaceVersion, devWorkspaceApiGroup, devworkspacePluralSubresource } from '../common';
 import { deletePolicy, deletionOptions } from '../common/models';
+import { IDevWorkspaceApi } from '../index';
+import { devworkspaceVersion, devWorkspaceApiGroup, devworkspacePluralSubresource } from '../common';
+import { RequestError } from './helper';
+import { delay } from '../common/helper';
 
 export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   private _axios: AxiosInstance;
@@ -30,20 +31,28 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   };
 
   async listInNamespace(namespace: string): Promise<IDevWorkspace[]> {
-    const resp = await this._axios.get(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}`
-    );
-    return resp.data.items;
+    try {
+      const resp = await this._axios.get(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}`
+      );
+      return resp.data.items;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
+    }
   }
 
   async getByName(
     namespace: string,
     workspaceName: string
   ): Promise<IDevWorkspace> {
-    const resp = await this._axios.get(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${workspaceName}`
-    );
-    return resp.data;
+    try {
+      const resp = await this._axios.get(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${workspaceName}`
+      );
+      return resp.data;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
+    }
   }
 
   async create(
@@ -51,56 +60,64 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
     routingClass: string,
     started = true
   ): Promise<IDevWorkspace> {
-    const devworkspace = devfileToDevWorkspace(devfile, routingClass, started);
-    const stringifiedDevWorkspace = JSON.stringify(devworkspace);
-
-    const resp = await this._axios.post(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devfile.metadata.namespace}/${devworkspacePluralSubresource}`,
-      stringifiedDevWorkspace,
-      {
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-        },
-      }
-    );
-
-    const responseData = await resp.data;
-    const namespace = responseData.metadata.namespace;
-    const name = responseData.metadata.name;
-
-    // we need to wait until the devworkspace has a status property
-    let found;
-    let count = 0;
-    while (count < 5 && !found) {
-      const potentialWorkspace = await this.getByName(namespace, name);
-      if (potentialWorkspace?.status) {
-        found = potentialWorkspace;
-      } else {
-        count += 1;
-        delay();
-      }
-    }
-    if (!found) {
-      throw new Error(
-        `Was not able to find a workspace with name ${name} in namespace ${namespace}`
+    try {
+      const devworkspace = devfileToDevWorkspace(devfile, routingClass, started);
+      const stringifiedDevWorkspace = JSON.stringify(devworkspace);
+  
+      const resp = await this._axios.post(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devfile.metadata.namespace}/${devworkspacePluralSubresource}`,
+        stringifiedDevWorkspace,
+        {
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+          },
+        }
       );
+  
+      const responseData = await resp.data;
+      const namespace = responseData.metadata.namespace;
+      const name = responseData.metadata.name;
+  
+      // we need to wait until the devworkspace has a status property
+      let found;
+      let count = 0;
+      while (count < 5 && !found) {
+        const potentialWorkspace = await this.getByName(namespace, name);
+        if (potentialWorkspace?.status) {
+          found = potentialWorkspace;
+        } else {
+          count += 1;
+          delay();
+        }
+      }
+      if (!found) {
+        throw new Error(
+          `Was not able to find a workspace with name ${name} in namespace ${namespace}`
+        );
+      }
+      return found;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
     }
-    return found;
   }
 
   async update(devworkspace: IDevWorkspace): Promise<IDevWorkspace> {
-    const name = devworkspace.metadata.name;
-    const namespace = devworkspace.metadata.namespace;
-    const resp = await this._axios.put(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${name}`,
-      devworkspace,
-      {
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-        },
-      }
-    );
-    return resp.data;
+    try {
+      const name = devworkspace.metadata.name;
+      const namespace = devworkspace.metadata.namespace;
+      const resp = await this._axios.put(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${name}`,
+        devworkspace,
+        {
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+          },
+        }
+      );
+      return resp.data;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
+    }
   }
 
   async delete(namespace: string, name: string): Promise<void> {
@@ -115,23 +132,27 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   }
 
   async changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace> {
-    const patch = [
-      {
-        path: '/spec/started',
-        op: 'replace',
-        value: started,
-      },
-    ];
-
-    const resp = await this._axios.patch(
-      `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${name}`,
-      patch,
-      {
-        headers: {
-          'Content-type': 'application/json-patch+json',
+    try {
+      const patch = [
+        {
+          path: '/spec/started',
+          op: 'replace',
+          value: started,
         },
-      }
-    );
-    return resp.data;
+      ];
+  
+      const resp = await this._axios.patch(
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${name}`,
+        patch,
+        {
+          headers: {
+            'Content-type': 'application/json-patch+json',
+          },
+        }
+      );
+      return resp.data;
+    } catch (e) {
+      return Promise.reject(new RequestError(e));
+    }
   }
 }

--- a/src/node/che-api.ts
+++ b/src/node/che-api.ts
@@ -20,9 +20,9 @@ import {
   projectsId,
 } from '../common';
 import { projectRequestModel } from '../common/models';
-import { handleGenericError } from './errors';
 import { findApi } from './helper';
 import { injectable } from 'inversify';
+import { NodeRequestError } from './errors';
 
 @injectable()
 export class NodeCheApi implements ICheApi {
@@ -70,7 +70,7 @@ export class NodeCheApi implements ICheApi {
         projectRequestModel(namespace)
       );
     } catch (e) {
-      throw handleGenericError(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 

--- a/src/node/helper.ts
+++ b/src/node/helper.ts
@@ -11,7 +11,6 @@
  */
 
 import * as k8s from '@kubernetes/client-node';
-import { handleGenericError } from './errors';
 
 export function isInCluster() {
     return 'KUBERNETES_SERVICE_HOST' in process.env && 'KUBERNETES_SERVICE_PORT' in process.env;
@@ -31,6 +30,6 @@ export async function findApi(apisApi: k8s.ApisApi, apiName: string, version?: s
           .length > 0;
       return Promise.resolve(filtered);
     } catch (e) {
-      throw handleGenericError(e);
+      return false;
     }
 }

--- a/src/node/template-api.ts
+++ b/src/node/template-api.ts
@@ -12,12 +12,12 @@
 
 import * as k8s from '@kubernetes/client-node';
 import { injectable } from 'inversify';
+import { NodeRequestError } from './errors';
 import { devWorkspaceApiGroup, devworkspaceTemplateSubresource, devworkspaceVersion } from '../common';
 import {
     IDevWorkspaceTemplate,
     IDevWorkspaceTemplateApi,
 } from '../types';
-import { handleGenericError } from './errors';
 
 @injectable()
 export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
@@ -37,7 +37,7 @@ export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
             );
             return (resp.body as any).items as IDevWorkspaceTemplate[];
         } catch (e) {
-            throw handleGenericError(e);
+            return Promise.reject(new NodeRequestError(e));
         }
     }
 
@@ -52,7 +52,7 @@ export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
             );
             return resp.body as IDevWorkspaceTemplate;
         } catch (e) {
-            throw handleGenericError(e);
+            return Promise.reject(new NodeRequestError(e));
         }
     }
 
@@ -70,7 +70,7 @@ export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
             );
             return resp.body as IDevWorkspaceTemplate;
         } catch (e) {
-            throw handleGenericError(e);
+            return Promise.reject(new NodeRequestError(e));
         }
     }
 
@@ -84,7 +84,7 @@ export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
                 name
             );
         } catch (e) {
-            throw handleGenericError(e);
+            return Promise.reject(new NodeRequestError(e));
         }
     }
 }

--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -21,9 +21,9 @@ import {
   devworkspaceVersion,
   devWorkspaceApiGroup,
 } from '../common';
-import { handleGenericError } from './errors';
 import { devfileToDevWorkspace } from '../common/converter';
 import { injectable } from 'inversify';
+import { NodeRequestError } from './errors';
 
 @injectable()
 export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
@@ -43,7 +43,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return (resp.body as any).items as IDevWorkspace[];
     } catch (e) {
-      throw handleGenericError(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 
@@ -61,7 +61,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.body as IDevWorkspace;
     } catch (e) {
-      throw handleGenericError(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 
@@ -82,7 +82,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.body as IDevWorkspace;
     } catch (e) {
-      throw handleGenericError(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 
@@ -112,8 +112,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       )
       return resp.body as IDevWorkspace;
     } catch (e) {
-      console.log(e);
-      throw handleGenericError(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 
@@ -127,7 +126,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
         name
       );
     } catch (e) {
-      throw handleGenericError(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 
@@ -163,7 +162,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.body as IDevWorkspace;
     } catch (e) {
-      throw handleGenericError(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 }


### PR DESCRIPTION
This PR makes it so that the errors coming from the browser side are handled the same way as on che workspace client. 

Fixes: https://github.com/eclipse/che/issues/19323

Now the errors are as followed:

If the response body exists (the normal case) you'll get an error like:
`devworkspaces.workspace.devfile.io "nodejs-stack" already exists`

If you scale down che you'll get this in the network tab of the dashboard:
`"503" returned by "/apis/workspace.devfile.io/v1alpha2/namespaces/kubeadmin-che/devworkspaces".`

If you load the dashboard with `yarn start --env.server=https://che-eclipse-che.apps-crc.testing` and then disconnect the dashboard you'll get:
`network issues occured while requesting "/apis/workspace.devfile.io/v1alpha2/namespaces/kubeadmin-che/devworkspaces".`

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>