### PR TITLE
Add in the ability to patch devworkspaces directly through the API

### DIFF
--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -15,6 +15,7 @@ import {
   IDevWorkspace,
   IDevWorkspaceApi,
   IDevWorkspaceDevfile,
+  Patch,
 } from '../types';
 import {
   devworkspacePluralSubresource,
@@ -130,19 +131,31 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
     }
   }
 
+  /**
+   * Patch a devworkspace
+   * @param devworkspace The devworkspace you want to patch
+   */
+  async patch(namespace: string, name: string, patches: Patch[]): Promise<IDevWorkspace> {
+    return this.createPatch(namespace, name, patches);
+  }
+
   async changeStatus(
     namespace: string,
     name: string,
     started: boolean
   ): Promise<IDevWorkspace> {
+    return this.createPatch(namespace, name, [{
+      op: 'replace',
+      path: '/spec/started',
+      value: started
+    }]);
+  }
+
+  private async createPatch(
+    namespace: string,
+    name: string,
+    patches: Patch[]) {
     try {
-      const patch = [
-        {
-          op: 'replace',
-          path: '/spec/started',
-          value: started,
-        },
-      ];
       const options = {
         headers: {
           'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH,
@@ -154,7 +167,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
         namespace,
         devworkspacePluralSubresource,
         name,
-        patch,
+        patches,
         undefined,
         undefined,
         undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface IDevWorkspaceApi {
     ): Promise<IDevWorkspace>;
     update(devworkspace: IDevWorkspace): Promise<IDevWorkspace>;
     delete(namespace: string, name: string): Promise<void>;
+    patch(namespace: string, name: string, patches: Patch[]): Promise<IDevWorkspace>;
     changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace>;
 }
 
@@ -61,23 +62,26 @@ export interface IDevWorkspace {
         creationTimestamp?: string;
         deletionTimestamp?: string;
         uid?: string;
+        annotations?: any;
     };
-    spec: {
-        started: boolean;
-        routingClass: string;
-        template: {
-            projects?: any;
-            components?: any[];
-            commands?: any;
-            events?: any;
-        }
-    };
+    spec: IDevWorkspaceSpec,
     status: {
         ideUrl: string;
         phase: string;
         devworkspaceId: string;
         message?: string;
     };
+}
+
+export interface IDevWorkspaceSpec {
+    started: boolean;
+    routingClass: string;
+    template: {
+        projects?: any;
+        components?: any[];
+        commands?: any;
+        events?: any;
+    }
 }
 
 export interface IDevWorkspaceTemplate {
@@ -120,6 +124,12 @@ export interface IKubernetesGroupsModel {
     versions: {
         version: string;
     }[];
+}
+
+export interface Patch {
+    op: string;
+    path: string;
+    value?: any;
 }
 
 export const INVERSIFY_TYPES = {


### PR DESCRIPTION
This PR makes it so that you can patch devworkspaces directly through the devworkspace client API. It's used to update the devworkspace in the dashboard editor.

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>