### PR TITLE
Rename instance of ideUrl to mainUrl

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface IDevWorkspace {
     };
     spec: IDevWorkspaceSpec,
     status: {
-        ideUrl: string;
+        mainUrl: string;
         phase: string;
         devworkspaceId: string;
         message?: string;


### PR DESCRIPTION
This PR renames the instance of ideUrl to mainUrl.

Part of: https://github.com/devfile/devworkspace-operator/issues/399

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>