### PR TITLE
feat: upgrade devfile schemaVersion to 2.2.0

### DIFF
--- a/src/common/converter.ts
+++ b/src/common/converter.ts
@@ -44,7 +44,7 @@ export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile, routingClas
 
 export function devWorkspaceToDevfile(devworkspace: IDevWorkspace): IDevWorkspaceDevfile {
     const template = {
-        schemaVersion: '2.0.0',
+        schemaVersion: '2.2.0',
         metadata: {
             name: devworkspace.metadata.name,
             namespace: devworkspace.metadata.namespace

--- a/test/fixtures/sample-devfile-plugins.yaml
+++ b/test/fixtures/sample-devfile-plugins.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 metadata:
   name: nodejs-stack
   namespace: sample

--- a/test/fixtures/sample-devfile.yaml
+++ b/test/fixtures/sample-devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.2.0
 metadata:
   name: nodejs-stack
   namespace: sample


### PR DESCRIPTION
feat: upgrade devfile schemaVersion to 2.2.0.

Note currently we just hard-code the latest stable version but there is an issue to respect original devfile schemaVersion:
https://github.com/eclipse/che/issues/19948