### PR TITLE
Add an ability to pass dw annotations via devfile attributes

### DIFF
--- a/src/common/converter.ts
+++ b/src/common/converter.ts
@@ -14,11 +14,16 @@ import { IDevWorkspace, IDevWorkspaceDevfile } from '../types';
 import { devworkspaceVersion, devWorkspaceApiGroup } from '.';
 
 export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile, routingClass: string, started: boolean): IDevWorkspace {
-    devfile.metadata.annotations = {};
+    const devfileAttributes = devfile.metadata.attributes || {};
+    const devWorkspaceAnnotations = devfileAttributes['dw.metadata.annotations'] || {}
     const template = {
         apiVersion: `${devWorkspaceApiGroup}/${devworkspaceVersion}`,
         kind: 'DevWorkspace',
-        metadata: devfile.metadata,
+        metadata: {
+            name: devfile.metadata.name,
+            namespace: devfile.metadata.namespace,
+            annotations: devWorkspaceAnnotations,
+        },
         spec: {
             started,
             routingClass,
@@ -47,7 +52,7 @@ export function devWorkspaceToDevfile(devworkspace: IDevWorkspace): IDevWorkspac
         schemaVersion: '2.1.0',
         metadata: {
             name: devworkspace.metadata.name,
-            namespace: devworkspace.metadata.namespace
+            namespace: devworkspace.metadata.namespace,
         },
     } as IDevWorkspaceDevfile;
     if (devworkspace.spec.template.projects) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export interface IDevWorkspaceDevfile {
     metadata: {
         name: string;
         namespace: string;
-        annotations?: {};
+        attributes?: {[key: string]:any};
     };
     projects?: any;
     components?: any;

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -28,6 +28,7 @@ describe('testing sample conversions', () => {
         test('the sample-devworkspace fixture should convert into sample-devfile fixture', () => {
             const input: any = yaml.load(fs.readFileSync(__dirname + '/fixtures/sample-devworkspace.yaml', 'utf-8'));
             const output = yaml.load(fs.readFileSync(__dirname + '/fixtures/sample-devfile.yaml', 'utf-8'));
+            delete (output as any).metadata.attributes;
             expect(devWorkspaceToDevfile(input)).toStrictEqual(output);
         });
     });

--- a/test/fixtures/sample-devfile-plugins.yaml
+++ b/test/fixtures/sample-devfile-plugins.yaml
@@ -2,6 +2,10 @@ schemaVersion: 2.1.0
 metadata:
   name: nodejs-stack
   namespace: sample
+  attributes:
+    author: Somebody
+    dw.metadata.annotations:
+      any.custom.settings: "true"
 projects:
   - name: project
     git:

--- a/test/fixtures/sample-devfile.yaml
+++ b/test/fixtures/sample-devfile.yaml
@@ -2,6 +2,10 @@ schemaVersion: 2.1.0
 metadata:
   name: nodejs-stack
   namespace: sample
+  attributes:
+    author: Somebody
+    dw.metadata.annotations:
+      any.custom.settings: "true"
 projects:
   - name: project    
     git:

--- a/test/fixtures/sample-devworkspace.yaml
+++ b/test/fixtures/sample-devworkspace.yaml
@@ -3,7 +3,8 @@ kind: DevWorkspace
 metadata:
   name: nodejs-stack
   namespace: sample
-  annotations: {}
+  annotations:
+    any.custom.settings: "true"
 spec:
   routingClass: che
   started: true


### PR DESCRIPTION
Dashboard needs to specify devworkspace annotations, but initially, it was implemented that DevWorkspace Client exposes Devfile objects but not DevWorkspace, which I think is a mistake and should be reworked.
But for time being, this PR adds an ability to pass devworkspace annotations via devfile attributes.

Devfile to test

```yaml
schemaVersion: 2.0.0
metadata:
  name: spring-petclinic
  attributes:
    dw.metadata.annotations:
      che.eclipse.org/devfile-source: |
        scm:
          repo: 'https://github.com/l0rd/spring-petclinic.git'
          fileName: devfile.yaml
projects:
  - name: spring-petclinic
    git:
      remotes:
        origin: 'https://github.com/l0rd/spring-petclinic.git'
components:
  - name: maven
    container:
      image: 'quay.io/eclipse/che-java8-maven:nightly'
      volumeMounts:
        - name: mavenrepo
          path: /root/.m2
      env:
        - name: ENV_VAR
          value: value
      memoryLimit: 1536M
  - name: mavenrepo
    volume: {}
```

![Screenshot_20210611_161135](https://user-images.githubusercontent.com/5887312/121691486-b776f680-cacf-11eb-827c-9381c1775d38.png)
