### PR TITLE
WIP Use devfile API

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "EPL-2.0",
   "dependencies": {
+    "@devfile/api": "^2.2.0-alpha-1627025889",
     "@kubernetes/client-node": "^0.14.0",
     "axios": "^0.21.1",
     "inversify": "^5.0.5",

--- a/src/browser/template-api.ts
+++ b/src/browser/template-api.ts
@@ -11,7 +11,8 @@
  */
 
 import { AxiosInstance } from 'axios';
-import { IDevWorkspaceTemplate, IDevWorkspaceTemplateApi } from '../types';
+import { V1alpha2DevWorkspaceTemplate } from '@devfile/api';
+import { IDevWorkspaceTemplateApi } from '../types';
 import { devworkspaceVersion, devWorkspaceApiGroup, devworkspaceTemplateSubresource } from '../common';
 import { BrowserRequestError } from './helper';
 
@@ -26,7 +27,7 @@ export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
     this._axios = axios;
   };
 
-  async listInNamespace(namespace: string): Promise<IDevWorkspaceTemplate[]> {
+  async listInNamespace(namespace: string): Promise<V1alpha2DevWorkspaceTemplate[]> {
     try {
       const resp = await this._axios.get(
         `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}`
@@ -40,7 +41,7 @@ export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
   async getByName(
     namespace: string,
     name: string
-  ): Promise<IDevWorkspaceTemplate> {
+  ): Promise<V1alpha2DevWorkspaceTemplate> {
     try {
       const resp = await this._axios.get(
         `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspaceTemplateSubresource}/${name}`
@@ -52,11 +53,11 @@ export class RestDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
   }
 
   async create(
-    devworkspaceTemplate: IDevWorkspaceTemplate,
-  ): Promise<IDevWorkspaceTemplate> {
+    devworkspaceTemplate: V1alpha2DevWorkspaceTemplate,
+  ): Promise<V1alpha2DevWorkspaceTemplate> {
     try {
       const resp = await this._axios.post(
-        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspaceTemplate.metadata.namespace}/${devworkspaceTemplateSubresource}`,
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspaceTemplate.metadata?.namespace}/${devworkspaceTemplateSubresource}`,
         devworkspaceTemplate,
         {
           headers: {

--- a/src/browser/workspace-api.ts
+++ b/src/browser/workspace-api.ts
@@ -11,7 +11,7 @@
  */
 
 import { AxiosInstance } from 'axios';
-import { devfileToDevWorkspace } from '../common/converter';
+
 import { Patch } from '../types';
 import { deletePolicy, deletionOptions } from '../common/models';
 import { IDevWorkspaceApi } from '../index';
@@ -57,14 +57,10 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   }
 
   async create(
-    devfile: V220Devfile,
-    routingClass: string,
-    started = true
+    devworkspace: V1alpha2DevWorkspace
   ): Promise<V1alpha2DevWorkspace> {
     try {
-      const devworkspace = devfileToDevWorkspace(devfile, routingClass, started);
       const stringifiedDevWorkspace = JSON.stringify(devworkspace);
-  
       const resp = await this._axios.post(
         `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspace.metadata?.namespace}/${devworkspacePluralSubresource}`,
         stringifiedDevWorkspace,

--- a/src/browser/workspace-api.ts
+++ b/src/browser/workspace-api.ts
@@ -12,12 +12,13 @@
 
 import { AxiosInstance } from 'axios';
 import { devfileToDevWorkspace } from '../common/converter';
-import { IDevWorkspace, IDevWorkspaceDevfile, Patch } from '../types';
+import { Patch } from '../types';
 import { deletePolicy, deletionOptions } from '../common/models';
 import { IDevWorkspaceApi } from '../index';
 import { delay } from '../common/helper';
 import { devworkspaceVersion, devWorkspaceApiGroup, devworkspacePluralSubresource } from '../common';
 import { BrowserRequestError } from './helper';
+import { V220Devfile, V1alpha2DevWorkspace } from '@devfile/api';
 
 export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   private _axios: AxiosInstance;
@@ -30,7 +31,7 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
     this._axios = axios;
   };
 
-  async listInNamespace(namespace: string): Promise<IDevWorkspace[]> {
+  async listInNamespace(namespace: string): Promise<V1alpha2DevWorkspace[]> {
     try {
       const resp = await this._axios.get(
         `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}`
@@ -44,7 +45,7 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   async getByName(
     namespace: string,
     name: string
-  ): Promise<IDevWorkspace> {
+  ): Promise<V1alpha2DevWorkspace> {
     try {
       const resp = await this._axios.get(
         `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${name}`
@@ -56,16 +57,16 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
   }
 
   async create(
-    devfile: IDevWorkspaceDevfile,
+    devfile: V220Devfile,
     routingClass: string,
     started = true
-  ): Promise<IDevWorkspace> {
+  ): Promise<V1alpha2DevWorkspace> {
     try {
       const devworkspace = devfileToDevWorkspace(devfile, routingClass, started);
       const stringifiedDevWorkspace = JSON.stringify(devworkspace);
   
       const resp = await this._axios.post(
-        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devfile.metadata.namespace}/${devworkspacePluralSubresource}`,
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspace.metadata?.namespace}/${devworkspacePluralSubresource}`,
         stringifiedDevWorkspace,
         {
           headers: {
@@ -101,12 +102,10 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
     }
   }
 
-  async update(devworkspace: IDevWorkspace): Promise<IDevWorkspace> {
+  async update(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace> {
     try {
-      const name = devworkspace.metadata.name;
-      const namespace = devworkspace.metadata.namespace;
       const resp = await this._axios.put(
-        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${namespace}/${devworkspacePluralSubresource}/${name}`,
+        `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/namespaces/${devworkspace.metadata?.namespace}/${devworkspacePluralSubresource}/${name}`,
         devworkspace,
         {
           headers: {
@@ -134,11 +133,11 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
    * Patch a devworkspace
    * @param devworkspace The devworkspace you want to patch
    */
-  async patch(namespace: string, name: string, patches: Patch[]): Promise<IDevWorkspace> {
+  async patch(namespace: string, name: string, patches: Patch[]): Promise<V1alpha2DevWorkspace> {
     return this.createPatch(namespace, name, patches);
   }
 
-  async changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace> {
+  async changeStatus(namespace: string, name: string, started: boolean): Promise<V1alpha2DevWorkspace> {
     return this.createPatch(namespace, name, [{
       op: 'replace',
       path: '/spec/started',

--- a/src/common/converter.ts
+++ b/src/common/converter.ts
@@ -10,61 +10,59 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { IDevWorkspace, IDevWorkspaceDevfile } from '../types';
-import { devworkspaceVersion, devWorkspaceApiGroup } from '.';
+import { V1alpha2DevWorkspace, V1alpha2DevWorkspaceSpecTemplate, V220Devfile } from '@devfile/api';
+import { devworkspaceKind, devworkspaceVersion, devWorkspaceApiGroup } from '.';
 
-export function devfileToDevWorkspace(devfile: IDevWorkspaceDevfile, routingClass: string, started: boolean): IDevWorkspace {
-    const devfileAttributes = devfile.metadata.attributes || {};
+//TODO Make clients of this method set namespace
+export function devfileToDevWorkspace(devfile: V220Devfile, routingClass: string, started: boolean): V1alpha2DevWorkspace {
+    const template: V1alpha2DevWorkspaceSpecTemplate = {}
+    if (devfile.projects) {
+        template.projects = devfile.projects;
+    }
+    if (devfile.components) {
+        template.components = devfile.components;
+    }
+    if (devfile.commands) {
+        template.commands = devfile.commands;
+    }
+    if (devfile.events) {
+        template.events = devfile.events;
+    }
+
+    const devfileAttributes = devfile.metadata?.attributes || {} as any;
     const devWorkspaceAnnotations = devfileAttributes['dw.metadata.annotations'] || {}
-    const template = {
+    return {
         apiVersion: `${devWorkspaceApiGroup}/${devworkspaceVersion}`,
-        kind: 'DevWorkspace',
+        kind: devworkspaceKind,
         metadata: {
-            name: devfile.metadata.name,
-            namespace: devfile.metadata.namespace,
+            name: devfile.metadata?.name,
             annotations: devWorkspaceAnnotations,
         },
         spec: {
             started,
             routingClass,
-            template: {
-                components: []
-            }
+            template: template,
         }
-    } as unknown as IDevWorkspace;
-    if (devfile.projects) {
-        template.spec.template.projects = devfile.projects;
     }
-    if (devfile.components) {
-        template.spec.template.components = devfile.components;
-    }
-    if (devfile.commands) {
-        template.spec.template.commands = devfile.commands;
-    }
-    if (devfile.events) {
-        template.spec.template.events = devfile.events;
-    }
-    return template;
-}
+  }
 
-export function devWorkspaceToDevfile(devworkspace: IDevWorkspace): IDevWorkspaceDevfile {
-    const template = {
+export function devWorkspaceToDevfile(devworkspace: V1alpha2DevWorkspace): V220Devfile {
+    const template: V220Devfile = {
         schemaVersion: '2.1.0',
         metadata: {
-            name: devworkspace.metadata.name,
-            namespace: devworkspace.metadata.namespace,
+            name: devworkspace?.metadata?.name  || '',
         },
-    } as IDevWorkspaceDevfile;
-    if (devworkspace.spec.template.projects) {
+    };
+    if (devworkspace.spec?.template?.projects) {
         template.projects = devworkspace.spec.template.projects;
     }
-    if (devworkspace.spec.template.components) {
+    if (devworkspace.spec?.template?.components) {
         template.components = filterPluginComponents(devworkspace.spec.template.components);
     }
-    if (devworkspace.spec.template.commands) {
+    if (devworkspace.spec?.template?.commands) {
         template.commands = devworkspace.spec.template.commands;
     }
-    if (devworkspace.spec.template.events) {
+    if (devworkspace.spec?.template?.events) {
         template.events = devworkspace.spec.template.events;
     }
     return template;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -10,15 +10,18 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-export const devworkspaceVersion = 'v1alpha2';
-export const devworkspacePluralSubresource = 'devworkspaces';
-export const devworkspaceSingularSubresource = 'devworkspace';
-export const devworkspaceTemplateSubresource = 'devworkspacetemplates';
+export const namespaceResources = 'namespaces';
 
 export const projectResources = 'projects';
 export const projectRequestResources = 'projectrequests';
 export const projectApiGroup = 'project.openshift.io';
 
-export const namespaceResources = 'namespaces';
-
 export const devWorkspaceApiGroup = 'workspace.devfile.io';
+export const devworkspaceVersion = 'v1alpha2';
+export const devworkspaceGroupVersion = `${devWorkspaceApiGroup}/${devworkspaceVersion}`
+
+export const devworkspaceKind = 'DevWorkspace';
+export const devworkspacePluralSubresource = 'devworkspaces';
+export const devworkspaceSingularSubresource = 'devworkspace';
+export const devworkspaceTemplateSubresource = 'devworkspacetemplates';
+

--- a/src/node/template-api.ts
+++ b/src/node/template-api.ts
@@ -14,10 +14,8 @@ import * as k8s from '@kubernetes/client-node';
 import { injectable } from 'inversify';
 import { NodeRequestError } from './errors';
 import { devWorkspaceApiGroup, devworkspaceTemplateSubresource, devworkspaceVersion } from '../common';
-import {
-    IDevWorkspaceTemplate,
-    IDevWorkspaceTemplateApi,
-} from '../types';
+import { V1alpha2DevWorkspaceTemplate } from '@devfile/api';
+import { IDevWorkspaceTemplateApi } from '../types';
 
 @injectable()
 export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
@@ -27,7 +25,7 @@ export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
         this.customObjectAPI = kc.makeApiClient(k8s.CustomObjectsApi);
     }
 
-    async listInNamespace(namespace: string): Promise<IDevWorkspaceTemplate[]> {
+    async listInNamespace(namespace: string): Promise<V1alpha2DevWorkspaceTemplate[]> {
         try {
             const resp = await this.customObjectAPI.listNamespacedCustomObject(
                 devWorkspaceApiGroup,
@@ -35,13 +33,13 @@ export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
                 namespace,
                 devworkspaceTemplateSubresource
             );
-            return (resp.body as any).items as IDevWorkspaceTemplate[];
+            return (resp.body as any).items as V1alpha2DevWorkspaceTemplate[];
         } catch (e) {
             return Promise.reject(new NodeRequestError(e));
         }
     }
 
-    async getByName(namespace: string, name: string): Promise<IDevWorkspaceTemplate> {
+    async getByName(namespace: string, name: string): Promise<V1alpha2DevWorkspaceTemplate> {
         try {
             const resp = await this.customObjectAPI.getNamespacedCustomObject(
                 devWorkspaceApiGroup,
@@ -50,25 +48,24 @@ export class NodeDevWorkspaceTemplateApi implements IDevWorkspaceTemplateApi {
                 devworkspaceTemplateSubresource,
                 name
             );
-            return resp.body as IDevWorkspaceTemplate;
+            return resp.body as V1alpha2DevWorkspaceTemplate;
         } catch (e) {
             return Promise.reject(new NodeRequestError(e));
         }
     }
 
     async create(
-        devworkspaceTemplate: IDevWorkspaceTemplate,
-    ): Promise<IDevWorkspaceTemplate> {
+        devworkspaceTemplate: V1alpha2DevWorkspaceTemplate,
+    ): Promise<V1alpha2DevWorkspaceTemplate> {
         try {
-            const namespace = devworkspaceTemplate.metadata.namespace;
             const resp = await this.customObjectAPI.createNamespacedCustomObject(
                 devWorkspaceApiGroup,
                 devworkspaceVersion,
-                namespace,
+                devworkspaceTemplate.metadata?.namespace || '',
                 devworkspaceTemplateSubresource,
                 devworkspaceTemplate
             );
-            return resp.body as IDevWorkspaceTemplate;
+            return resp.body as V1alpha2DevWorkspaceTemplate;
         } catch (e) {
             return Promise.reject(new NodeRequestError(e));
         }

--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -21,7 +21,6 @@ import {
   devworkspaceVersion,
   devWorkspaceApiGroup,
 } from '../common';
-import { devfileToDevWorkspace } from '../common/converter';
 import { injectable } from 'inversify';
 import { NodeRequestError } from './errors';
 
@@ -66,12 +65,9 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
   }
 
   async create(
-    devfile: V220Devfile,
-    routingClass: string,
-    started: boolean = true
+    devworkspace: V1alpha2DevWorkspace
   ): Promise<V1alpha2DevWorkspace> {
     try {
-      const devworkspace = devfileToDevWorkspace(devfile, routingClass, started);
       const resp = await this.customObjectAPI.createNamespacedCustomObject(
         devWorkspaceApiGroup,
         devworkspaceVersion,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,7 @@ export interface IDevWorkspaceApi {
     config: k8s.KubeConfig | AxiosInstance;
     listInNamespace(namespace: string): Promise<V1alpha2DevWorkspace[]>;
     getByName(namespace: string, name: string): Promise<V1alpha2DevWorkspace>;
-    create(
-        devfile: V220Devfile,
-        routingClass: string,
-        started?: boolean,
-    ): Promise<V1alpha2DevWorkspace>;
+    create(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace>;
     update(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace>;
     delete(namespace: string, name: string): Promise<void>;
     patch(namespace: string, name: string, patches: Patch[]): Promise<V1alpha2DevWorkspace>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@
 
 import * as k8s from '@kubernetes/client-node';
 import { AxiosInstance } from 'axios';
+import { V1alpha2DevWorkspace, V1alpha2DevWorkspaceTemplate, V220Devfile } from '@devfile/api';
 
 export interface IDevWorkspaceClient {
     getNodeApi(config: INodeConfig): IDevWorkspaceClientApi;
@@ -19,25 +20,25 @@ export interface IDevWorkspaceClient {
 
 export interface IDevWorkspaceApi {
     config: k8s.KubeConfig | AxiosInstance;
-    listInNamespace(namespace: string): Promise<IDevWorkspace[]>;
-    getByName(namespace: string, name: string): Promise<IDevWorkspace>;
+    listInNamespace(namespace: string): Promise<V1alpha2DevWorkspace[]>;
+    getByName(namespace: string, name: string): Promise<V1alpha2DevWorkspace>;
     create(
-        devfile: IDevWorkspaceDevfile,
+        devfile: V220Devfile,
         routingClass: string,
         started?: boolean,
-    ): Promise<IDevWorkspace>;
-    update(devworkspace: IDevWorkspace): Promise<IDevWorkspace>;
+    ): Promise<V1alpha2DevWorkspace>;
+    update(devworkspace: V1alpha2DevWorkspace): Promise<V1alpha2DevWorkspace>;
     delete(namespace: string, name: string): Promise<void>;
-    patch(namespace: string, name: string, patches: Patch[]): Promise<IDevWorkspace>;
-    changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace>;
+    patch(namespace: string, name: string, patches: Patch[]): Promise<V1alpha2DevWorkspace>;
+    changeStatus(namespace: string, name: string, started: boolean): Promise<V1alpha2DevWorkspace>;
 }
 
 export interface IDevWorkspaceTemplateApi {
     config: k8s.KubeConfig | AxiosInstance;
-    listInNamespace(namespace: string): Promise<IDevWorkspaceTemplate[]>;
-    getByName(namespace: string, name: string): Promise<IDevWorkspaceTemplate>;
+    listInNamespace(namespace: string): Promise<V1alpha2DevWorkspaceTemplate[]>;
+    getByName(namespace: string, name: string): Promise<V1alpha2DevWorkspaceTemplate>;
     delete(namespace: string, name: string): Promise<void>;
-    create(template: IDevWorkspaceTemplate): Promise<IDevWorkspaceTemplate>;
+    create(template: V1alpha2DevWorkspaceTemplate): Promise<V1alpha2DevWorkspaceTemplate>;
 }
 
 export interface IDevWorkspaceClientApi {
@@ -53,47 +54,6 @@ export interface ICheApi {
     initializeNamespace(namespace: string): Promise<void>;
 }
 
-export interface IDevWorkspace {
-    apiVersion: string;
-    kind: string;
-    metadata: {
-        name: string;
-        namespace: string;
-        creationTimestamp?: string;
-        deletionTimestamp?: string;
-        uid?: string;
-        annotations?: any;
-    };
-    spec: IDevWorkspaceSpec,
-    status: {
-        mainUrl: string;
-        phase: string;
-        devworkspaceId: string;
-        message?: string;
-    };
-}
-
-export interface IDevWorkspaceSpec {
-    started: boolean;
-    routingClass: string;
-    template: {
-        projects?: any;
-        components?: any[];
-        commands?: any;
-        events?: any;
-    }
-}
-
-export interface IDevWorkspaceTemplate {
-    apiVersion: string;
-    kind: string;
-    metadata: {
-        name: string;
-        namespace: string;
-        ownerReferences: OwnerRefs[];
-    };
-    spec: IDevWorkspaceDevfile;
-}
 
 export interface OwnerRefs {
     apiVersion: string;
@@ -101,20 +61,6 @@ export interface OwnerRefs {
     name: string;
     uid: string;
 }
-
-export interface IDevWorkspaceDevfile {
-    schemaVersion: string;
-    metadata: {
-        name: string;
-        namespace: string;
-        attributes?: {[key: string]:any};
-    };
-    projects?: any;
-    components?: any;
-    commands?: any;
-    events?: any;
-}
-
 export interface INodeConfig {
     inCluster: boolean;
 }

--- a/test/fixtures/sample-devfile-plugins.yaml
+++ b/test/fixtures/sample-devfile-plugins.yaml
@@ -1,7 +1,6 @@
 schemaVersion: 2.1.0
 metadata:
   name: nodejs-stack
-  namespace: sample
   attributes:
     author: Somebody
     dw.metadata.annotations:

--- a/test/fixtures/sample-devfile.yaml
+++ b/test/fixtures/sample-devfile.yaml
@@ -1,7 +1,6 @@
 schemaVersion: 2.1.0
 metadata:
   name: nodejs-stack
-  namespace: sample
   attributes:
     author: Somebody
     dw.metadata.annotations:

--- a/test/fixtures/sample-devworkspace.yaml
+++ b/test/fixtures/sample-devworkspace.yaml
@@ -2,7 +2,6 @@ apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspace
 metadata:
   name: nodejs-stack
-  namespace: sample
   annotations:
     any.custom.settings: "true"
 spec:

--- a/test/fixtures/sample-dwt.yaml
+++ b/test/fixtures/sample-dwt.yaml
@@ -2,7 +2,6 @@ apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspaceTemplate
 metadata:
   name: sample-dwt
-  namespace: sample
 spec:
   projects: []
   components: []

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -13,6 +13,7 @@
 import { isInCluster } from '../src/node/helper';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
+import { devfileToDevWorkspace } from '../src';
 import { INVERSIFY_TYPES } from '../src';
 import { delay } from '../src/common/helper';
 import { conditionalTest, isIntegrationTestEnabled } from './utils/suite';
@@ -56,8 +57,9 @@ describe('DevWorkspace API integration testing against cluster', () => {
              }
              expect(namespaceExists).toBe(true);
 
+
             // check that creation works
-            const newDevWorkspace = await nodeApi.devworkspaceApi.create(devfile, 'che', true);
+            const newDevWorkspace = await nodeApi.devworkspaceApi.create(devfileToDevWorkspace(devfile, 'che', true));
             expect(newDevWorkspace.metadata?.name).toBe(name);
             expect(newDevWorkspace.metadata?.namespace).toBe(namespace);
 
@@ -79,7 +81,6 @@ describe('DevWorkspace API integration testing against cluster', () => {
             await delay(2000);
             const currentDevWorkspace = await nodeApi.devworkspaceApi.getByName(namespace, name);
             const sampleRouting = 'sample';
-            expect(currentDevWorkspace.spec).toBeNull()
             if (currentDevWorkspace.spec) {
                 currentDevWorkspace.spec.routingClass = sampleRouting;
             } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,17 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@devfile/api@^2.2.0-alpha-1627025889":
+  version "2.2.0-alpha-1627025889"
+  resolved "https://registry.yarnpkg.com/@devfile/api/-/api-2.2.0-alpha-1627025889.tgz#f640371c8f3296bee0d8f81318c4ac654f489e24"
+  integrity sha512-MnH0XdM3gRJuG6vXUpw1rEj0Pd7bFQwNy+O/3r5fnppkZPSSNYX8PSJFGGnijxnvDLK9VKvNGZbDdi+bSRuBew==
+  dependencies:
+    "@types/bluebird" "3.5.21"
+    "@types/request" "*"
+    bluebird "^3.5.0"
+    request "^2.81.0"
+    rewire "^3.0.2"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -591,6 +602,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bluebird@3.5.21":
+  version "3.5.21"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.21.tgz#567615589cc913e84a28ecf9edb031732bdf2634"
+  integrity sha512-6UNEwyw+6SGMC/WMI0ld0PS4st7Qq51qgguFrFizOSpGvZiqe9iswztFSdZvwJBEhLOy2JaxNE6VC7yMAlbfyQ==
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -717,7 +733,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
   integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
 
-"@types/request@^2.47.1":
+"@types/request@*", "@types/request@^2.47.1":
   version "2.48.5"
   resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
   integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
@@ -1620,7 +1636,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.24.1:
+babel-plugin-transform-es2015-block-scoping@^6.24.1, babel-plugin-transform-es2015-block-scoping@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
   integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
@@ -2054,7 +2070,7 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bluebird@^3.5.5:
+bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6996,7 +7012,7 @@ request-promise-native@^1.0.8:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.88.0, request@^2.88.2:
+request@^2.81.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -7129,6 +7145,14 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+rewire@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rewire/-/rewire-3.0.2.tgz#25e5413c4f1676eb3247d1884198b3a265408bbd"
+  integrity sha512-ejkkt3qYnsQ38ifc9llAAzuHiGM7kR8N5/mL3aHWgmWwet0OMFcmJB8aTsMV2PBHCWxNVTLCeRfBpEa8X2+1fw==
+  dependencies:
+    babel-core "^6.26.0"
+    babel-plugin-transform-es2015-block-scoping "^6.26.0"
 
 rfc4648@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
This PR does two stuff:
- Use Devfile API types instead of declaring itsown;
- Make DevWorkspaceAPI#Create supply DevWorkspace instead of devfile, to give clients more power. In addition, then we have DevWorkspaceAPI consistent with DevWorkspaceTemplate;

PR is ready to review but should not be merged before Dashboard PR is created and ready to merge. https://github.com/eclipse-che/che-dashboard/pull/272

It fixes https://github.com/eclipse/che/issues/19579