### PR TITLE
feat: create namespace on K8s if it does not exist

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -14,8 +14,11 @@ export const devworkspaceVersion = 'v1alpha2';
 export const devworkspacePluralSubresource = 'devworkspaces';
 export const devworkspaceSingularSubresource = 'devworkspace';
 export const devworkspaceTemplateSubresource = 'devworkspacetemplates';
-export const projectsId = 'projects';
-export const projectRequestId = 'projectrequests';
 
+export const projectResources = 'projects';
+export const projectRequestResources = 'projectrequests';
 export const projectApiGroup = 'project.openshift.io';
+
+export const namespaceResources = 'namespaces';
+
 export const devWorkspaceApiGroup = 'workspace.devfile.io';

--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -22,6 +22,16 @@ export const projectRequestModel = (namespace: string) => {
   };
 };
 
+export const namespaceModel = (namespace: string) => {
+  return {
+    apiVersion: `v1`,
+    kind: 'Namespace',
+    metadata: {
+      name: namespace,
+    },
+  };
+};
+
 export enum deletePolicy {
   Background='Background',
   Foreground='Foreground'

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -80,9 +80,15 @@ describe('DevWorkspace API integration testing against cluster', () => {
             // check that deletion works
             await nodeApi.devworkspaceApi.delete(namespace, name);
             await delay(5000);
-            const finalNamespaces = await nodeApi.devworkspaceApi.listInNamespace(namespace);
-            expect(finalNamespaces.length).toBe(0);
-
+            const dwsInNamespace = await nodeApi.devworkspaceApi.listInNamespace(namespace);
+            var nonTerminatingWsCount = 0
+            for (const dw of dwsInNamespace) {
+                console.log(dw.status?.phase)
+                if (dw.status?.phase != 'Terminating') {
+                    nonTerminatingWsCount++;
+                }
+            }
+            expect(nonTerminatingWsCount).toBe(0);
             done();
         }, 60000);
 

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -44,10 +44,16 @@ describe('DevWorkspace API integration testing against cluster', () => {
             expect(isApiEnabled).toBe(true);
 
             // check that the namespace is initialized
-            await nodeApi.cheApi.initializeNamespace(namespace);
-            await delay(5000);
-            const projectExists = await (nodeApi.cheApi as any).doesProjectExist(namespace);
-            expect(projectExists).toBe(true);
+             // initialize namespace if it doesn't exist
+             await nodeApi.cheApi.initializeNamespace(namespace);
+             await delay(5000);
+             var namespaceExists: boolean;
+             if (await (nodeApi.cheApi as any).isOpenShift()) {
+                namespaceExists = await (nodeApi.cheApi as any).doesProjectExist(namespace);
+             } else {
+                namespaceExists = await (nodeApi.cheApi as any).doesNamespaceExist(namespace);
+             }
+             expect(namespaceExists).toBe(true);
 
             // check that creation works
             const newDevWorkspace = await nodeApi.devworkspaceApi.create(devfile, 'che', true);
@@ -83,7 +89,6 @@ describe('DevWorkspace API integration testing against cluster', () => {
             const dwsInNamespace = await nodeApi.devworkspaceApi.listInNamespace(namespace);
             var nonTerminatingWsCount = 0
             for (const dw of dwsInNamespace) {
-                console.log(dw.status?.phase)
                 if (dw.status?.phase != 'Terminating') {
                     nonTerminatingWsCount++;
                 }
@@ -105,11 +110,16 @@ describe('DevWorkspace API integration testing against cluster', () => {
             const isApiEnabled = await nodeApi.isDevWorkspaceApiEnabled();
             expect(isApiEnabled).toBe(true);
 
-            // initialize project if it doesn't exist
+            // initialize namespace if it doesn't exist
             await nodeApi.cheApi.initializeNamespace(namespace);
             await delay(5000);
-            const projectExists = await (nodeApi.cheApi as any).doesProjectExist(namespace);
-            expect(projectExists).toBe(true);
+            var namespaceExists: boolean;
+            if (await (nodeApi.cheApi as any).isOpenShift()) {
+               namespaceExists = await (nodeApi.cheApi as any).doesProjectExist(namespace);
+            } else {
+               namespaceExists = await (nodeApi.cheApi as any).doesNamespaceExist(namespace);
+            }
+            expect(namespaceExists).toBe(true);
 
             // check that creation works
             const newDWT = await nodeApi.templateApi.create(dwt);


### PR DESCRIPTION
I tested it on minikube with devworkspace enabled where I used patched Che Operator provided by platform team.

![Screenshot_20210624_165610](https://user-images.githubusercontent.com/5887312/123275568-18112500-d50d-11eb-8d6c-e7d6ed67ba18.png)

it's for https://github.com/eclipse/che/issues/20014