### PR TITLE
fix: fix check if namespace exists

### DIFF
--- a/src/browser/che-api.ts
+++ b/src/browser/che-api.ts
@@ -46,11 +46,11 @@ export class RestCheApi implements ICheApi {
     }
   }
 
-  private async doesNamespaceExist(projectName: string): Promise<boolean> {
+  private async doesNamespaceExist(namespace: string): Promise<boolean> {
     try {
-      const projects = await this.axios.get(`/api/v1/${projectResources}`);
-      for (const proj of projects.data.items) {
-        if (proj.metadata.name === projectName) {
+      const namespaces = await this.axios.get(`/api/v1/${namespaceResources}`);
+      for (const n of namespaces.data.items) {
+        if (n.metadata.name === namespace) {
           return true;
         }
       }


### PR DESCRIPTION
fix: fix check if namespace exists

it's the last piece for https://github.com/eclipse/che/issues/20014

I tested it on minikube and now I don't have try to create namespace when it already exists
![Screenshot_20210705_162925](https://user-images.githubusercontent.com/5887312/124480524-069f0700-ddb0-11eb-8372-4ecbf641dea1.png)
