### PR TITLE
Remove unneeded API

### DIFF
--- a/src/browser/workspace-api.ts
+++ b/src/browser/workspace-api.ts
@@ -138,14 +138,6 @@ export class RestDevWorkspaceApi implements IDevWorkspaceApi {
     return this.createPatch(namespace, name, patches);
   }
 
-  async changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace> {
-    return this.createPatch(namespace, name, [{
-      op: 'replace',
-      path: '/spec/started',
-      value: started
-    }]);
-  }
-
   private async createPatch(
     namespace: string,
     name: string,

--- a/src/node/che-api.ts
+++ b/src/node/che-api.ts
@@ -52,7 +52,7 @@ export class NodeCheApi implements ICheApi {
         }
       }
     } catch (e) {
-      console.log(e);
+      return Promise.reject(new NodeRequestError(e));
     }
   }
 

--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -139,18 +139,6 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
     return this.createPatch(namespace, name, patches);
   }
 
-  async changeStatus(
-    namespace: string,
-    name: string,
-    started: boolean
-  ): Promise<IDevWorkspace> {
-    return this.createPatch(namespace, name, [{
-      op: 'replace',
-      path: '/spec/started',
-      value: started
-    }]);
-  }
-
   private async createPatch(
     namespace: string,
     name: string,

--- a/src/node/workspace-api.ts
+++ b/src/node/workspace-api.ts
@@ -44,7 +44,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return (resp.body as any).items as IDevWorkspace[];
     } catch (e) {
-      return Promise.reject(new NodeRequestError(e));
+      throw new NodeRequestError(e);
     }
   }
 
@@ -62,7 +62,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.body as IDevWorkspace;
     } catch (e) {
-      return Promise.reject(new NodeRequestError(e));
+      throw new NodeRequestError(e);
     }
   }
 
@@ -83,7 +83,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.body as IDevWorkspace;
     } catch (e) {
-      return Promise.reject(new NodeRequestError(e));
+      throw new NodeRequestError(e);
     }
   }
 
@@ -113,7 +113,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       )
       return resp.body as IDevWorkspace;
     } catch (e) {
-      return Promise.reject(new NodeRequestError(e));
+      throw new NodeRequestError(e);
     }
   }
 
@@ -127,7 +127,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
         name
       );
     } catch (e) {
-      return Promise.reject(new NodeRequestError(e));
+      throw new NodeRequestError(e);
     }
   }
 
@@ -163,7 +163,7 @@ export class NodeDevWorkspaceApi implements IDevWorkspaceApi {
       );
       return resp.body as IDevWorkspace;
     } catch (e) {
-      return Promise.reject(new NodeRequestError(e));
+      throw new NodeRequestError(e);
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface IDevWorkspaceApi {
     update(devworkspace: IDevWorkspace): Promise<IDevWorkspace>;
     delete(namespace: string, name: string): Promise<void>;
     patch(namespace: string, name: string, patches: Patch[]): Promise<IDevWorkspace>;
-    changeStatus(namespace: string, name: string, started: boolean): Promise<IDevWorkspace>;
 }
 
 export interface IDevWorkspaceTemplateApi {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -71,10 +71,6 @@ describe('DevWorkspace API integration testing against cluster', () => {
             expect(singleNamespace.metadata.name).toBe(name);
             expect(singleNamespace.metadata.namespace).toBe(namespace);
 
-            // check that updating works
-            const changedWorkspace = await nodeApi.devworkspaceApi.changeStatus(namespace, name, false);
-            expect(changedWorkspace.spec.started).toBe(false);
-
             await delay(2000);
             const currentDevWorkspace = await nodeApi.devworkspaceApi.getByName(namespace, name);
             const sampleRouting = 'sample';


### PR DESCRIPTION
### What does this PR do?
This PR removes unneeded change status workspace API.  Returns an error if it happens during nitializeNamespace.

### What issues does this PR fix or reference?
It's related to https://github.com/eclipse/che/issues/19987

Signed-off-by: Oleksii Orel <oorel@redhat.com>