### PR TITLE
Renames the callback & remove redundant checks

### DIFF
--- a/src/node/services/API/workspace-watcher.ts
+++ b/src/node/services/API/workspace-watcher.ts
@@ -29,18 +29,16 @@ export class NodeDevWorkspaceWatcher implements IDevWorkspaceWatcher {
         return this.customObjectWatch.watch(path, {}, (type: string, devworkspace: IDevWorkspace) => {
             const status = devworkspace!.status!.phase;
             const workspaceId = devworkspace!.status!.devworkspaceId;
-            if (devworkspace.kind !== 'DevWorkspace' || !workspaceId || !status) {
+            if (!workspaceId || !status) {
                 return;
             }
 
             if (type === 'ADDED') {
                 callbacks.onAdded(devworkspace);
             } else if (type === 'MODIFIED') {
-                callbacks.onStatusChange({ workspaceId, status });
+                callbacks.onModified(devworkspace);
             } else if (type === 'DELETED') {
-                if (status === 'Terminating') {
-                    callbacks.onDeleted(workspaceId);
-                }
+                callbacks.onDeleted(workspaceId);
             } else {
                 callbacks.onError(`Error: Unknown type '${type}'.`);
             }

--- a/src/node/services/API/workspace-watcher.ts
+++ b/src/node/services/API/workspace-watcher.ts
@@ -29,9 +29,6 @@ export class NodeDevWorkspaceWatcher implements IDevWorkspaceWatcher {
         return this.customObjectWatch.watch(path, {}, (type: string, devworkspace: IDevWorkspace) => {
             const status = devworkspace!.status!.phase;
             const workspaceId = devworkspace!.status!.devworkspaceId;
-            if (!workspaceId || !status) {
-                return;
-            }
 
             if (type === 'ADDED') {
                 callbacks.onAdded(devworkspace);

--- a/src/node/services/API/workspace-watcher.ts
+++ b/src/node/services/API/workspace-watcher.ts
@@ -27,7 +27,6 @@ export class NodeDevWorkspaceWatcher implements IDevWorkspaceWatcher {
         const path = `/apis/${devWorkspaceApiGroup}/${devworkspaceVersion}/watch/namespaces/${namespace}/devworkspaces`;
 
         return this.customObjectWatch.watch(path, {}, (type: string, devworkspace: IDevWorkspace) => {
-            const status = devworkspace!.status!.phase;
             const workspaceId = devworkspace!.status!.devworkspaceId;
 
             if (type === 'ADDED') {

--- a/src/node/services/helpers/index.ts
+++ b/src/node/services/helpers/index.ts
@@ -34,6 +34,6 @@ export async function findApi(apisApi: k8s.ApisApi, apiName: string, version?: s
     }
 }
 
-export async function delay(ms = 500): Promise<void> {
+export async function delay(ms: number = 500): Promise<void> {
     await new Promise<void>(resolve => setTimeout(resolve, ms));
-};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface IDevWorkspaceClient {
 }
 
 export type IDevWorkspaceCallbacks = {
-    onStatusChange: (statusUpdate: { status: string; workspaceId: string }) => void;
+    onModified: (workspace: IDevWorkspace) => void;
     onDeleted: (workspaceId: string) => void;
     onAdded: (workspace: IDevWorkspace) => void;
     onError: (error: string) => void;


### PR DESCRIPTION
### What does this PR do?
This PR renames the callback:   'onStatusChange' -> 'onModified'

### What issues does this PR fix or reference?
It needs for https://github.com/eclipse/che/issues/19987

Signed-off-by: Oleksii Orel <oorel@redhat.com>